### PR TITLE
Extend gpg sign (Fixes #7)

### DIFF
--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -117,10 +117,15 @@ extract_git_option <- function(name) {
 
 get_key_candidates <- function(user_name, user_email) {
   existing_keys <- gpg::gpg_list_keys()
-  if (is.null(user_name) | is.null(user_email)) {
+  if (is.null(user_name)) {
     subset(
       existing_keys,
-      existing_keys$name == user_name | existing_keys$email == user_email
+      existing_keys$email == user_email
+    )
+  } else if (is.null(user_email)) {
+    subset(
+      existing_keys,
+      existing_keys$name == user_name
     )
   } else {
     subset(

--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -117,20 +117,26 @@ extract_git_option <- function(name) {
 
 get_key_candidates <- function(user_name, user_email) {
   existing_keys <- gpg::gpg_list_keys()
+  filter_keys_on_name_and_email_if_provided(
+    existing_keys, user_name, user_email
+  )
+}
+
+filter_keys_on_name_and_email_if_provided <- function(keys, user_name, user_email) {
   if (is.null(user_name)) {
     subset(
-      existing_keys,
-      existing_keys$email == user_email
+      keys,
+      keys$email == user_email
     )
   } else if (is.null(user_email)) {
     subset(
-      existing_keys,
-      existing_keys$name == user_name
+      keys,
+      keys$name == user_name
     )
   } else {
     subset(
-      existing_keys,
-      existing_keys$name == user_name & existing_keys$email == user_email
+      keys,
+      keys$name == user_name & keys$email == user_email
     )
   }
 }

--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -19,10 +19,7 @@
 #' @param key A character string containing the ID of a pre-existing key to use.
 #'   If `NULL` and key cannot be found based on name and email unambiguously, a
 #'   new key will be created.
-#' @param global boolean, set commit signing in global or local got config.
-#' @param force_new boolean, if `TRUE` and key is `NULL`, new key will be generated
-#'   and used even if an existing key can be found based on name and email
-#'   unambiguously.
+#' @param global boolean, set commit signing in global or local git config.
 #' @return A character string containing the ID of the key that was provided or
 #'   generated.
 #' @export
@@ -31,7 +28,7 @@
 #' \dontrun{
 #' newkey <- sign_commits_with_key("John Doe", "johndoe@example.com")
 #' }
-sign_commits_with_key <- function(name, email, key = NULL, global = TRUE, force_new = FALSE) {
+sign_commits_with_key <- function(name, email, key = NULL, global = TRUE) {
   if (!is.null(key)) {
     git2r::config(global = TRUE, user.signingkey = key, commit.gpgsign = "true")
     return(key)
@@ -46,7 +43,7 @@ sign_commits_with_key <- function(name, email, key = NULL, global = TRUE, force_
 
   key_candidates <- get_key_candidates(name, email)
 
-  if (force_new | nrow(key_candidates) == 0L) {
+  if (nrow(key_candidates) == 0L) {
     key <- generate_key_with_name_and_email(name, email)
   } else if (nrow(key_candidates) == 1L) {
     message("Existing key found and will be used to sign commits.")
@@ -54,7 +51,7 @@ sign_commits_with_key <- function(name, email, key = NULL, global = TRUE, force_
   } else {
     message(paste0(capture.output(key_candidates), collapse = "\n"))
     stop(
-      "There are multiple keys, disambiguate with the key param or set force_new = TRUE to use a newly generated key.",
+      "There are multiple keys, you must disambiguate with providing the key param.",
       call. = FALSE
     )
   }

--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -22,11 +22,11 @@
 sign_commits_with_key <- function(name, email, passphrase = NULL, key = NULL) {
 
   if (missing(name)) {
-    name <- git2r::config()$global$user.name
+    name <- extract_git_option("user.name")
   }
 
   if (missing(email)) {
-    email <- git2r::config()$global$user.email
+    email <- extract_git_option("user.email")
   }
 
   if (is.null(name) | is.null(email)) {
@@ -57,7 +57,9 @@ sign_commits_with_key <- function(name, email, passphrase = NULL, key = NULL) {
 #' it; if it fails, it will print the public key for you to copy manually into
 #' GitHub.
 #'
-#' See https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/ for more information on tokens.
+#' See
+#' https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+#' for more information on tokens.
 #'
 #' @param key A character string containing the ID of a key to use. See
 #'   [gpg::gpg_list_keys()]; if you haven't created a key, see
@@ -88,5 +90,14 @@ gh_store_key <- function(key, .token = NULL) {
         sep = "\n"
       )
     )
+  }
+}
+
+extract_git_option <- function(name) {
+  git_config <- git2r::config()
+  if (is.null(git_config[["local"]][[name]])) {
+    git_config[["global"]][[name]]
+  } else {
+    git_config[["local"]][[name]]
   }
 }

--- a/man/sign_commits_with_key.Rd
+++ b/man/sign_commits_with_key.Rd
@@ -4,20 +4,27 @@
 \alias{sign_commits_with_key}
 \title{GPG sign all git commits}
 \usage{
-sign_commits_with_key(name, email, passphrase = NULL, key = NULL)
+sign_commits_with_key(name, email, key = NULL, global = TRUE,
+  force_new = FALSE)
 }
 \arguments{
 \item{name}{A character string containing your name. If not provided,
-`sign_commits_with_key()` will look in your global git configuration.}
+`sign_commits_with_key()` will look first in your local then in your global
+git configuration.}
 
 \item{email}{A character string containing your email address. If not
-provided, `sign_commits_with_key()` will look in your global git
-configuration.}
-
-\item{passphrase}{An optional passphrase to protect the keypair.}
+provided, `sign_commits_with_key()` will look first in your local then in
+your global git configuration.}
 
 \item{key}{A character string containing the ID of a pre-existing key to use.
-If `NULL`, a new key will be created.}
+If `NULL` and key cannot be found based on name and email unambiguously, a
+new key will be created.}
+
+\item{global}{boolean, set commit signing in global or local got config.}
+
+\item{force_new}{boolean, if `TRUE` and key is `NULL`, new key will be generated
+and used even if an existing key can be found based on name and email
+unambiguously.}
 }
 \value{
 A character string containing the ID of the key that was provided or
@@ -26,6 +33,14 @@ A character string containing the ID of the key that was provided or
 \description{
 Configure git to sign all commits using GPG. If no existing key is provided,
 `sign_commits_with_key()` will create a new key and use it for signing.
+}
+\details{
+In case of already existing key(s) for convenience an appropriate key will be
+identified based on git config, or if git config is not set, it is sufficient
+to provide one of name or email. This is especially handy if you have
+multiple email addresses used with git and thus would like to set-up commit
+signing on a per-repo basis. In this case supply the email and set the global
+param to `FALSE`.
 }
 \examples{
 \dontrun{

--- a/man/sign_commits_with_key.Rd
+++ b/man/sign_commits_with_key.Rd
@@ -35,7 +35,9 @@ identified based on git config, or if git config is not set, it is sufficient
 to provide one of name or email. This is especially handy if you have
 multiple email addresses used with git and thus would like to set-up commit
 signing on a per-repo basis. In this case supply the email and set the global
-param to `FALSE`.
+param to `FALSE`. If you accidentally set that all commits should be signed
+you can revert this by deleting the `commit.gpgsign` and `user.signingkey` git
+options.
 }
 \examples{
 \dontrun{

--- a/man/sign_commits_with_key.Rd
+++ b/man/sign_commits_with_key.Rd
@@ -4,8 +4,7 @@
 \alias{sign_commits_with_key}
 \title{GPG sign all git commits}
 \usage{
-sign_commits_with_key(name, email, key = NULL, global = TRUE,
-  force_new = FALSE)
+sign_commits_with_key(name, email, key = NULL, global = TRUE)
 }
 \arguments{
 \item{name}{A character string containing your name. If not provided,
@@ -20,11 +19,7 @@ your global git configuration.}
 If `NULL` and key cannot be found based on name and email unambiguously, a
 new key will be created.}
 
-\item{global}{boolean, set commit signing in global or local got config.}
-
-\item{force_new}{boolean, if `TRUE` and key is `NULL`, new key will be generated
-and used even if an existing key can be found based on name and email
-unambiguously.}
+\item{global}{boolean, set commit signing in global or local git config.}
 }
 \value{
 A character string containing the ID of the key that was provided or

--- a/tests/testthat/test-sign_commits.R
+++ b/tests/testthat/test-sign_commits.R
@@ -1,0 +1,37 @@
+context("find matching existing keys")
+
+test_that("no matching keys returned if initial df is empty", {
+  df <- data.frame(name = character(0), email = character(0))
+  expect_equal(
+    nrow(filter_keys_on_name_and_email_if_provided(df, "", "")),
+    0L
+  )
+})
+
+test_that("no matching keys returned if both ids are NULL", {
+  df <- data.frame(name = "a", email = "b")
+  expect_equal(
+    nrow(filter_keys_on_name_and_email_if_provided(df, NULL, NULL)),
+    0L
+  )
+})
+
+test_that("matching keys returned if one id is NULL", {
+  df <- data.frame(name = c("a", "a"), email = c("b", "b"))
+  expect_equal(
+    nrow(filter_keys_on_name_and_email_if_provided(df, "a", NULL)),
+    2L
+  )
+  expect_equal(
+    nrow(filter_keys_on_name_and_email_if_provided(df, NULL, "b")),
+    2L
+  )
+})
+
+test_that("matching key returned if both ids provided", {
+  df <- data.frame(name = c("a", "a"), email = c("b", "c"))
+  expect_equal(
+    nrow(filter_keys_on_name_and_email_if_provided(df, "a", "c")),
+    1L
+  )
+})


### PR DESCRIPTION
supperted scenarios:

- existing key passed, set it in current git repo / globally
- existing key identifiable based on name and or email, set it in current git repo / globally
- existing key not found for name/email: generate new key and set it in current repo / globally

Most straightforward: generate new key based in name / email and set it globally.

Also fairly easy: set existing key based on email (work email, do not have to list gpg keys first)

Another somewhat orthogonal change: I move the password from being a function param to asking it for with a prompt. I believe this has two advantages:
- password won't show up in Rhistory
- you only need it if new key has to be created.
As this change is mostly orthogonal, I am happy to remove it from this pull request.