### PR TITLE
Fix gpg sign: set user.email 

### DIFF
--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -33,7 +33,7 @@
 #' }
 sign_commits_with_key <- function(name, email, key = NULL, global = TRUE) {
   if (!is.null(key)) {
-    git2r::config(global = TRUE, user.signingkey = key, commit.gpgsign = "true")
+    git2r::config(global = global, user.signingkey = key, commit.gpgsign = "true")
     return(key)
   }
 

--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -59,7 +59,12 @@ sign_commits_with_key <- function(name, email, key = NULL, global = TRUE) {
     )
   }
 
-  git2r::config(global = global, user.signingkey = key, commit.gpgsign = "true")
+  git2r::config(
+    global = global,
+    user.signingkey = key,
+    commit.gpgsign = "true",
+    user.email = email
+  )
 
   return(key)
 }

--- a/man/gh_store_key.Rd
+++ b/man/gh_store_key.Rd
@@ -20,7 +20,9 @@ it; if it fails, it will print the public key for you to copy manually into
 GitHub.
 }
 \details{
-See https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/ for more information on tokens.
+See
+https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+for more information on tokens.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-ropsec.R
+++ b/tests/testthat/test-ropsec.R
@@ -1,6 +1,0 @@
-context("minimal package functionality")
-test_that("we can do something", {
-
-  # expect_that(mtcars, is_a("data.frame"))
-
-})


### PR DESCRIPTION
Fixes #9 

- if key provided, no not necessarily set it globally
- set user.email config for gpg sign to work: if repo email is different from global email and local user.email was not set previously