### PR TITLE
enhance documentation of `gh_store_key`

### DIFF
--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -116,10 +116,7 @@ gh_store_key <- function(key, .token = NULL) {
     )
     return(invisible(pubkey))
   }
-  gh_attempt <- try(
-    gh::gh("POST /user/gpg_keys", armored_public_key = pubkey, .token = .token),
-    silent = TRUE
-  )
+  gh_attempt <- gh_attempt_key_upload(pubkey, .token)
 
   if (inherits(gh_attempt, "try-error")) {
     if (inherits(attr(gh_attempt, "condition"), "http_error_422")) {
@@ -144,6 +141,13 @@ gh_store_key <- function(key, .token = NULL) {
     )
   }
   invisible(pubkey)
+}
+
+gh_attempt_key_upload <- function(pubkey, .token) {
+  try(
+    gh::gh("POST /user/gpg_keys", armored_public_key = pubkey, .token = .token),
+    silent = TRUE
+  )
 }
 
 set_key_to_sign_commits <- function(key, global) {

--- a/man/gh_store_key.Rd
+++ b/man/gh_store_key.Rd
@@ -11,7 +11,9 @@ gh_store_key(key, .token = NULL)
 [gpg::gpg_list_keys()]; if you haven't created a key, see
 [sign_commits_with_key()] or [gpg::gpg_keygen()].}
 
-\item{.token}{GitHub Personal Access Token.}
+\item{.token}{GitHub Personal Access Token with at least `write:gpg_key`
+scope enabled. You can grant access to tokens
+[here](https://github.com/settings/tokens).}
 }
 \description{
 `gh_store_key()` add the public key associated with a key ID to your GitHub
@@ -20,6 +22,10 @@ it; if it fails, it will print the public key for you to copy manually into
 GitHub.
 }
 \details{
+If you do not have a GitHub Personal Access Token setup or you want to store
+your key on Gitlab or other service you can either call this function without
+a token and then add the printed public key manually or call
+[gpg::gpg_export()] with `newkey` and add the returned public key manually.
 See
 https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 for more information on tokens.
@@ -27,6 +33,9 @@ for more information on tokens.
 \examples{
 \dontrun{
 newkey <- sign_commits_with_key("John Doe", "johndoe@example.com")
+# if you do not have personal access token for github
 gh_store_key(newkey)
+# if your GitHub Personal Access Token is stored in `.Renviron` as GITHUB_PAT
+gh_store_key(newkey, Sys.getenv('GITHUB_PAT'))
 }
 }

--- a/vignettes/sign-commits.Rmd
+++ b/vignettes/sign-commits.Rmd
@@ -18,8 +18,13 @@ knitr::opts_chunk$set(
 
 
 It is good practice to sign your commits so that your commits can be verified as certainly made by you and not by someone impersonating you.
-One technology to enable this is GPG, which has an R wrapper written by Jeroen Ooms.
+
 One technology to enable this is [GPG](https://gnupg.org/), which has an [R wrapper](https://github.com/jeroen/gpg) written by [Jeroen Ooms](https://github.com/jeroen). The current package provides helper functions and aims to ease the process as much as possible.
+
+Having verified commits has two components:
+
+- [sign your commits](#sign_commits) (with private key)
+- [upload your public key](#upload_key) to GitHub, Gitlab, etc so that they can verify your commits (with public key)
 
 First, make sure that dependencies are installed:
 
@@ -34,6 +39,8 @@ If you are interested in background,
 ```{r}
 library(ropsec)
 ```
+
+# Sign commits {#sign_commits}
 
 ## Default use-case
 
@@ -167,3 +174,15 @@ Selection: 1")
 
 
 You may choose to set one of them globally which thus will be the default key to use in a repository where the repository level configs are not set to a different value.
+
+# Upload your public key to repository management services {#upload_key}
+
+To upload to GitHub without leaving your R session you need the following:
+
+- a personal access token with at least `write:gpg_key` scope enabled. You can grant access to tokens [here](https://github.com/settings/tokens).
+- `gh_store_key(key, token)`
+
+You can use any service (GitHub, Gitlab etc) which supports GPG by manually adding your **public** GPG key which you can get by
+
+- `gh_store_key(new_key)` or
+- `gpg::gpg_export(new_key)`


### PR DESCRIPTION
- do not attempt to call github API without token
- specify token as .token
- what access is needed
- what to do with other services (not GitHub)
- include information in vignette

Fixes #14