### PR TITLE
use getPass to retrieve password in a safer way

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Imports:
     stats,
     utils,
     openssl,
-    sys
+    sys,
+    getPass
 RoxygenNote: 6.1.0
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/R/sign-commits.R
+++ b/R/sign-commits.R
@@ -221,9 +221,19 @@ generate_key_with_name_and_email <- function(name, email) {
     "`", email, "`", communicate_source_of_param(email), "\n",
     "will be used to generate a new gpg key."
   )
-  passphrase <- readline(
-    prompt = "Please enter password for new gpg key (can be blank): "
+  passphrase <- getPass::getPass(
+    msg = paste(
+      "Please enter password for new gpg key",
+      "(can only be blank if you are using terminal),",
+      "to cancel press `Cancel` in Rstudio on `Ctrl + c` in terminal: "
+    )
   )
+  if (is.null(passphrase)) {
+    stop(
+      "GPG key generation cancelled by user, stopping execution.",
+      call. = FALSE
+    )
+  }
   if (passphrase == "") {
     passphrase <- NULL
   }

--- a/tests/testthat/test-sign_commits.R
+++ b/tests/testthat/test-sign_commits.R
@@ -208,8 +208,24 @@ test_that("extract git option: not available", {
   expect_equal(extract_git_option("nonexistent_option"), NULL)
 })
 
+test_that("safe getPass is called to retrieve password", {
+  getPassMock <- mockery::mock("")
+  mockery::stub(generate_key_with_name_and_email, "getPass::getPass", getPassMock)
+  mockery::stub(generate_key_with_name_and_email, "gpg::gpg_keygen", "")
+  generate_key_with_name_and_email("John Doe", "jd@example.com")
+  mockery::expect_called(getPassMock, 1)
+})
+
+test_that("throw error if gpg password prompt cancelled", {
+  mockery::stub(generate_key_with_name_and_email, "getPass::getPass", NULL)
+  expect_error(
+    generate_key_with_name_and_email("John Doe", "jd@example.com"),
+    "GPG key generation cancelled by user"
+  )
+})
+
 test_that("generate key: if no password, use NULL", {
-  mockery::stub(generate_key_with_name_and_email, "readline", "")
+  mockery::stub(generate_key_with_name_and_email, "getPass::getPass", "")
   keygen_mock <- mockery::mock()
   mockery::stub(generate_key_with_name_and_email, "gpg::gpg_keygen", keygen_mock)
   generate_key_with_name_and_email("John Doe", "jd@example.com")
@@ -220,7 +236,7 @@ test_that("generate key: if no password, use NULL", {
 })
 
 test_that("generate key: message used name and email", {
-  mockery::stub(generate_key_with_name_and_email, "readline", "")
+  mockery::stub(generate_key_with_name_and_email, "getPass::getPass", "")
   mockery::stub(generate_key_with_name_and_email, "gpg::gpg_keygen", NULL)
   expect_message(
     generate_key_with_name_and_email("John Doe", "jd@example.com"),
@@ -229,7 +245,7 @@ test_that("generate key: message used name and email", {
 })
 
 test_that("generate key: message based on source of param", {
-  mockery::stub(generate_key_with_name_and_email, "readline", "")
+  mockery::stub(generate_key_with_name_and_email, "getPass::getPass", "")
   mockery::stub(generate_key_with_name_and_email, "gpg::gpg_keygen", NULL)
   name <- "John Doe"
   attr(name, "local") <- TRUE


### PR DESCRIPTION
it is shown as **** on display on systems that support this

drawback: now in Rstudio you must provide password

Fixes #25