### PR TITLE
Make sure badges will be in the sidebar

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -10,9 +10,11 @@ options(width=120)
 
 # rOpenSci Unconf 18 Project : ropsec
 
+<!-- badges: start -->
 [![Travis build status](https://travis-ci.org/ropenscilabs/ropsec.svg?branch=master)](https://travis-ci.org/ropenscilabs/ropsec)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/55vx8b5jckpa216a?svg=true)](https://ci.appveyor.com/project/czeildi/ropsec-w5fnj)
 [![Coverage status](https://codecov.io/gh/ropenscilabs/ropsec/branch/master/graph/badge.svg)](https://codecov.io/github/ropenscilabs/ropsec?branch=master)
+<!-- badges: end -->
 
 Personal Workstation Safety Checks and Utilities
 


### PR DESCRIPTION
In pkgdown dev version now badges inside such comments will be recognized as badges paragraph and end up in the sidebar (see e.g. https://docs.ropensci.org/magick/index.html).

Also note that Jeroen has started working on central builds for pkgdown packages so there's a website deployed for `ropsec` at https://docs.ropensci.org/ropsec/index.html, using rOpenSci's `rotemplate` package for styling.